### PR TITLE
Avoid file conflict.

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,6 +86,9 @@ def gcp_tweets_to_db():
         filepath = entity["localfilepath"]
         params = {'group_entity_id': group_entity_id}
 
+        # don't want interference with same file names from file function
+        if os.path.isfile(filepath): os.remove(filepath) 
+
         # Find most recent Tweet date
         response = requests.get(url = url_latest_tweet, params = params)
         most_recent_tweet_date = response.text

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def gcp_tweets_to_db():
     comment = "TWINT webserver."
     
     # TODO: set to GCP before deployment
-    # entities = ParseFilesFromConfig(ReadConfigFileLocal())
+    #entities = ParseFilesFromConfig(ReadConfigFileLocal())
     entities = ParseFilesFromConfig(ReadConfigFileGCP())
 
     for entity in entities:


### PR DESCRIPTION
Previous release combined the tweet search into files and into the database into one function (temporarily). Both use files in the background - with the same names.

The database function (called first) deletes any files before it starts. It will then create files, which it deletes before completion. Subsequently the file based function will create its own files.

This is a temporary solution (but also a potentially a temporary problem).